### PR TITLE
Configure page size

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ This tap:
         "client_secret": <CLIENT_SECRET>,
         "redirect_uri": <REDIRECT_URI>,
         "refresh_token": <REFRESH_TOKEN>,
-        "quota_limit": <QUOTA_LIMIT>
+        "quota_limit": <QUOTA_LIMIT>,
+        "page_size": <PAGE_SIZE>
     }
     ```
     The following are required values: `start_date`, `client_id`, `client_secret`, `redirect_uri`, `refresh_token`
-    The following are optional values: `quota_limit`
+    The following are optional values: `quota_limit`, `page_size`
 
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
 

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -21,6 +21,7 @@ REQUIRED_CONFIG_KEYS = [
     'refresh_token'
 ]
 
+
 def do_discover(client):
     LOGGER.info('Testing authentication')
     try:
@@ -35,6 +36,7 @@ def do_discover(client):
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
+
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
@@ -44,6 +46,7 @@ def main():
             do_discover(client)
         else:
             sync(client,
+                 parsed_args.config,
                  parsed_args.catalog,
                  parsed_args.state,
                  parsed_args.config['start_date'])

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -6,6 +6,7 @@ import argparse
 
 import singer
 from singer import metadata
+from singer.catalog import write_catalog
 
 from tap_outreach.client import OutreachClient
 from tap_outreach.discover import discover
@@ -22,7 +23,7 @@ REQUIRED_CONFIG_KEYS = [
 ]
 
 
-def do_discover(client):
+def check_auth(client):
     LOGGER.info('Testing authentication')
     try:
         client.get(
@@ -31,22 +32,19 @@ def do_discover(client):
     except:
         raise Exception('Error testing Outreach authentication')
 
-    LOGGER.info('Starting discover')
-    catalog = discover()
-    json.dump(catalog.to_dict(), sys.stdout, indent=2)
-    LOGGER.info('Finished discover')
-
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
+    catalog = parsed_args.catalog if parsed_args.catalog else discover()
 
-    with OutreachClient(parsed_args.config) as client:
-        if parsed_args.discover:
-            do_discover(client)
-        else:
+    if parsed_args.discover:
+        write_catalog(catalog)
+    else:
+        with OutreachClient(parsed_args.config) as client:
+            check_auth(client)
             sync(client,
-                 parsed_args.config,
-                 parsed_args.catalog,
-                 parsed_args.state,
-                 parsed_args.config['start_date'])
+                parsed_args.config,
+                catalog,
+                parsed_args.state,
+                parsed_args.config['start_date'])

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -6,8 +6,10 @@ from singer.catalog import Catalog, CatalogEntry, Schema
 SCHEMAS = {}
 FIELD_METADATA = {}
 
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
 
 def get_schemas():
     global SCHEMAS, FIELD_METADATA
@@ -24,7 +26,7 @@ def get_schemas():
         stream_name = file_name[:-5]
         with open(os.path.join(schemas_path, file_name)) as data_file:
             schema = json.load(data_file)
-            
+
         SCHEMAS[stream_name] = schema
 
         metadata = []
@@ -42,6 +44,7 @@ def get_schemas():
         FIELD_METADATA[stream_name] = metadata
 
     return SCHEMAS, FIELD_METADATA
+
 
 def discover():
     schemas, field_metadata = get_schemas()

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -237,7 +237,7 @@ def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
     # Pagination: https://api.outreach.io/api/v2/docs#pagination
     # Changed to cursor-based pagination (not offset); offset still used for logging
     offset = 0
-    count = config.get('page_size', 250)
+    count = int(config.get('page_size', 250))
     has_more = True
     max_modified = last_datetime
     paginate_datetime = last_datetime

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -2,11 +2,9 @@ import singer
 from singer import metrics, metadata, Transformer
 from singer.bookmarks import set_currently_syncing
 
-from tap_outreach.discover import discover
-
 LOGGER = singer.get_logger()
 
-STEAM_CONFIGS = {
+STREAM_CONFIGS = {
     'accounts': {
         'url_path': 'accounts',
         'replication': 'incremental',
@@ -232,7 +230,7 @@ def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
 
     write_schema(stream)
 
-    stream_config = STEAM_CONFIGS[stream_name]
+    stream_config = STREAM_CONFIGS[stream_name]
     filter_field = stream_config.get('filter_field')
     fks = stream_config.get('fks', [])
 
@@ -305,12 +303,7 @@ def update_current_stream(state, stream_name=None):
 
 
 def sync(client, config, catalog, state, start_date):
-    if not catalog:
-        catalog = discover()
-        selected_streams = catalog.streams
-    else:
-        selected_streams = catalog.get_selected_streams(state)
-
+    selected_streams = catalog.get_selected_streams(state)
     selected_streams = sorted(selected_streams, key=lambda x: x.tap_stream_id)
 
     for stream in selected_streams:


### PR DESCRIPTION
# Description of change
This PR is all of the work in #6, but pushed here so that tests could run and I could add the `int(config.get('page_size'))`

# Manual QA steps
 - Ran the tap
 
# Risks
 - Low
   - If you don't have `page_size` in your config, there's a default value
   - If you do have it, we can use it whether the type of the value is a string or an int
      - Not sure what a float would do here - Would the API error if the requests send in a float?
 
# Rollback steps
 - revert this branch, bump the version
