### PR TITLE
Adding sequence, sequence_template, sequence_state, sequence_step tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ This tap:
 
     For Sync mode:
     ```bash
-    > tap-outreach --config tap_config.json --catalog catalog.json > state.json
+    > tap-outreach --config config.json --catalog catalog.json > state.json
     > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
     ```
     To load to json files to verify outputs:
     ```bash
-    > tap-outreach --config tap_config.json --catalog catalog.json | target-json > state.json
+    > tap-outreach --config config.json --catalog catalog.json | target-json > state.json
     > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
     ```
     To pseudo-load to [Stitch Import API](https://github.com/singer-io/target-stitch) with dry run:
     ```bash
-    > tap-outreach --config tap_config.json --catalog catalog.json | target-stitch --config target_config.json --dry-run > state.json
+    > tap-outreach --config config.json --catalog catalog.json | target-stitch --config target_config.json --dry-run > state.json
     > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
     ```
 
@@ -130,9 +130,9 @@ This tap:
     ```
 
 
-    To [check the tap](https://github.com/singer-io/singer-tools#singer-check-tap) and verify working:
+    To [check the tap](https://github.com/singer-io/singer-tools#singer-check-tap), install singer-check-tap and verify working:
     ```bash
-    > tap-outreach --config tap_config.json --catalog catalog.json | singer-check-tap > state.json
+    > tap-outreach --config config.json --catalog catalog.json | singer-check-tap > state.json
     > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
     ```
     Check tap resulted in the following:

--- a/tap_outreach/schemas/sequence_states.json
+++ b/tap_outreach/schemas/sequence_states.json
@@ -1,0 +1,161 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": [
+          "integer"
+        ]
+      },
+      "activeAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "bounceCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "callCompletedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "clickCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "createdAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "deliverCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "errorReason": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "failureCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "negativeReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "naturalReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "openCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "optOutCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "pauseReason": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "positiveReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "repliedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "replyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "scheduleCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "state": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "stateChangedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "updatedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "accountId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "creatorId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "prospectId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sequenceId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      }
+    }
+  }

--- a/tap_outreach/schemas/sequence_steps.json
+++ b/tap_outreach/schemas/sequence_steps.json
@@ -1,0 +1,152 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": [
+          "integer"
+        ]
+      },
+      "bounceCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "clickCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "createdAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "date": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date"
+      },
+      "deliverCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "displayName": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "failureCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "interval": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "negativeReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "neutralReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "openCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "optOutCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "order": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "positiveReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "replyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "scheduleCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "stepType": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "taskAutoskipDelay": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "taskNote": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "updatedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "creatorId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sequenceId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "updaterId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      }
+    }
+  }

--- a/tap_outreach/schemas/sequence_templates.json
+++ b/tap_outreach/schemas/sequence_templates.json
@@ -1,0 +1,122 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": [
+          "integer"
+        ]
+      },
+      "bounceCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "clickCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "createdAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "deliverCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "enabled": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "enabledAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "failureCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "isReply": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "negaitveReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "neutralReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "openCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "optOutCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "positiveReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "replyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "scheduleCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "updatedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "creatorId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "updaterId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      }
+    }
+  }

--- a/tap_outreach/schemas/sequences.json
+++ b/tap_outreach/schemas/sequences.json
@@ -152,7 +152,7 @@
       "primaryReplyAction": {
         "type": [
           "null",
-          "integer"
+          "string"
         ]
       },
       "primaryReplyPauseDuration": {

--- a/tap_outreach/schemas/sequences.json
+++ b/tap_outreach/schemas/sequences.json
@@ -125,6 +125,12 @@
           "integer"
         ]
       },
+      "numRepliedProspects": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
       "openCount": {
         "type": [
           "null",

--- a/tap_outreach/schemas/sequences.json
+++ b/tap_outreach/schemas/sequences.json
@@ -1,0 +1,269 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": [
+          "integer"
+        ]
+      },
+      "automationPercentage": {
+        "type": [
+          "null",
+          "number"
+        ]
+      },
+      "bounceCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "clickCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "createdAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "deliverCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "description": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "durationInDays": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "enabled": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "enabledAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "failureCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "finishOnReply": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "lastUsedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "locked": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "lockedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "maxActivations": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "negativeReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "neutralReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "numContactedProspects": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "openCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "optOutCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "positiveReplyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "primaryReplyAction": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "primaryReplyPauseDuration": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "replyCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "scheduleCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "scheduleIntervalType": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "secondaryReplyAction": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "secondaryReplyPauseDuration": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sequenceStepCount": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "sequenceType": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "shareType": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "tags": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "throttleCapacity": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "throttleMaxAddsPerDay": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "throttlePaused": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "throttlePausedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "transactional": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "updatedAt": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "creatorId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "ownerId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "updaterId": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      }
+    }
+  }

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -124,19 +124,19 @@ STREAM_CONFIGS = {
         'fks': ['creatorId', 'ownerid', 'updaterId']
     },
     'sequence_states': {
-        'url_path': 'sequence_states',
+        'url_path': 'sequenceStates',
         'replication': 'incremental',
         'filter_field': 'updatedAt',
         'fks': ['accountid', 'creatorId', 'prospectId', 'sequenceId']
     },
     'sequence_steps': {
-        'url_path': 'sequence_steps',
+        'url_path': 'sequenceSteps',
         'replication': 'incremental',
         'filter_field': 'updatedAt',
         'fks': ['creatorId', 'sequenceId', 'updaterId']
     },
     'sequence_templates': {
-        'url_path': 'sequence_templates',
+        'url_path': 'sequenceTemplates',
         'replication': 'incremental',
         'filter_field': 'updatedAt',
         'fks': ['creatorId', 'updaterId']

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -137,7 +137,7 @@ STREAM_CONFIGS = {
     },
     'sequence_templates': {
         'url_path': 'sequenceTemplates',
-        'replication': 'incremental',
+        'replication': 'full',
         'filter_field': 'updatedAt',
         'fks': ['creatorId', 'updaterId']
     },

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -117,6 +117,30 @@ STREAM_CONFIGS = {
         'filter_field': 'updatedAt',
         'fks': ['creatorId', 'updaterId']
     },
+    'sequences': {
+        'url_path': 'sequences',
+        'replication': 'incremental',
+        'filter_field': 'updatedAt',
+        'fks': ['creatorId', 'ownerid', 'updaterId']
+    },
+    'sequence_states': {
+        'url_path': 'sequence_states',
+        'replication': 'incremental',
+        'filter_field': 'updatedAt',
+        'fks': ['accountid', 'creatorId', 'prospectId', 'sequenceId']
+    },
+    'sequence_steps': {
+        'url_path': 'sequence_steps',
+        'replication': 'incremental',
+        'filter_field': 'updatedAt',
+        'fks': ['creatorId', 'sequenceId', 'updaterId']
+    },
+    'sequence_templates': {
+        'url_path': 'sequence_templates',
+        'replication': 'incremental',
+        'filter_field': 'updatedAt',
+        'fks': ['creatorId', 'updaterId']
+    },
     'tasks': {
         'url_path': 'tasks',
         'replication': 'incremental',


### PR DESCRIPTION
# Description of change
Added the sequence, sequence_template, sequence_state, sequence_step tables to the STREAM_CONFIGS object in sync.py. Added schemas for each table. 

# Manual QA steps
 - Qa'ed against Outreach Documentation 
 
# Risks
 - Foreign Key relationships based off of table behavior in UI. 
 
# Rollback steps
 - revert this branch
