### PR TITLE
Version bump to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0
+  * Adds sequence, sequence_template, sequence_state, sequence_step tables [#11](https://github.com/singer-io/tap-outreach/pull/11)
+
 ## 0.5.0
   * Add `page_size` a config option [#7](https://github.com/singer-io/tap-outreach/pull/7)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='0.5.0',
+      version='0.6.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
## 0.6.0
  * Adds sequence, sequence_template, sequence_state, sequence_step tables [#11](https://github.com/singer-io/tap-outreach/pull/11)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
