### PR TITLE
Bump to v0.7.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.0
+  * Add the `name` field to the `Events` stream [#13](https://github.com/singer-io/tap-outreach/pull/13)
+
 ## 0.6.0
   * Adds sequence, sequence_template, sequence_state, sequence_step tables [#11](https://github.com/singer-io/tap-outreach/pull/11)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='0.6.0',
+      version='0.7.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
This is the version bump for #13 

## 0.7.0
  * Add the `name` field to the `Events` stream [#13](https://github.com/singer-io/tap-outreach/pull/13)

# Manual QA steps
 - See #13 
 
# Risks
 - See #13 
 
# Rollback steps
 - revert #13 and bump the version
