### PR TITLE
add dataConnections metadata, fix updaterId on prospects

### DIFF
--- a/tap_outreach/schemas/accounts.json
+++ b/tap_outreach/schemas/accounts.json
@@ -351,6 +351,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/calls.json
+++ b/tap_outreach/schemas/calls.json
@@ -174,6 +174,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/events.json
+++ b/tap_outreach/schemas/events.json
@@ -92,6 +92,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/mailings.json
+++ b/tap_outreach/schemas/mailings.json
@@ -46,13 +46,6 @@
       ],
       "format": "date-time"
     },
-    "updatedAt": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "date-time"
-    },
     "deliveredAt": {
       "type": [
         "null",
@@ -285,6 +278,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/opportunities.json
+++ b/tap_outreach/schemas/opportunities.json
@@ -719,6 +719,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/prospects.json
+++ b/tap_outreach/schemas/prospects.json
@@ -834,6 +834,18 @@
       ],
       "format": "date-time"
     },
+    "updaterId": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "updaterType": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "voipPhones": {
       "type": [
         "null",
@@ -912,11 +924,17 @@
         "integer"
       ]
     },
-    "updaterId": {
+    "dataConnections": {
       "type": [
         "null",
-        "integer"
-      ]
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 } 

--- a/tap_outreach/schemas/stages.json
+++ b/tap_outreach/schemas/stages.json
@@ -50,6 +50,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/tasks.json
+++ b/tap_outreach/schemas/tasks.json
@@ -181,6 +181,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }

--- a/tap_outreach/schemas/users.json
+++ b/tap_outreach/schemas/users.json
@@ -356,6 +356,18 @@
         "null",
         "integer"
       ]
+    },
+    "dataConnections": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
# Description of change
The main change is that I added the "dataConnections" metadata for objects that support it, as this is extremely useful to map objects to other 3rd party platforms that Outreach is integrated with such as Salesforce.

Additionally I included a fix for issue #20 however this fix is different than the pull request already outstanding. The current pull request to fix this issue simply allows the relationship value to override the new attributes, however I instead remove the relationship for "updater" from the prospect schema and add the new attributes "updaterId" and "updaterType" instead. The relationship appears to only return an ID value when the updater is a user and null when it is not a user, however the new attributes appear to give the ID of any object that update the object including but not limited to users. Any downstream logic such as joins using "updaterId" that assume it is always contains a user ID would now need to check the "updaterType" attribute to see if it's a user or not.

# Manual QA steps
- Run a refresh of data using the new schemas and check the results.
 
# Risks
 - Could impact downstream logic that relies on "updaterId" always being a user ID value.
 
# Rollback steps
 - revert this branch
