### PR TITLE
Fixes broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a [Singer](https://singer.io) tap that produces JSON-formatted data
 following the [Singer
-spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
+spec](https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#singer-specification).
 
 This tap:
 


### PR DESCRIPTION
# Description of change
I noticed the link to the Singer spec was outdated, so I created this PR.

# Manual QA steps
 - Clicked new link, it worked.
 
# Risks
 - Continuing to have an incorrect link.
 
# Rollback steps
 - revert this branch
