### PR TITLE
Relationship precedence over attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.0
+  * Relationship precedence over attributes for `Prospects` stream [#25](https://github.com/singer-io/tap-outreach/pull/25)
+
 ## 0.7.0
   * Add the `name` field to the `Events` stream [#13](https://github.com/singer-io/tap-outreach/pull/13)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='0.7.0',
+      version='0.8.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -227,11 +227,10 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
                             raise Exception(
                                 'null or `id` field expected for `data` relationship')
 
-if stream != "prospects":
-     if fk_field_name in record_flat:
-          raise Exception(
-                                '`{}` exists as both an attribute and generated relationship
-                                name'.format(fk_field_name))
+                        # potential fix for the issue - https://github.com/singer-io/tap-outreach/issues/20
+                        if stream.tap_stream_id != "prospects":
+                            if fk_field_name in record_flat:
+                                raise Exception('`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
 
                         if data_value == None:
                             record_flat[fk_field_name] = None

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -227,9 +227,11 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
                             raise Exception(
                                 'null or `id` field expected for `data` relationship')
 
-                        if fk_field_name in record_flat:
-                            raise Exception(
-                                '`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
+                        # January 2023: Let relationship value of record take precedence over attribute value (will take precedence at line 214)
+                        # (https://github.com/singer-io/tap-outreach/issues/20)
+                        # if fk_field_name in record_flat:
+                        #     raise Exception(
+                        #         '`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
 
                         if data_value == None:
                             record_flat[fk_field_name] = None

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -227,11 +227,11 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
                             raise Exception(
                                 'null or `id` field expected for `data` relationship')
 
-                        # January 2023: Let relationship value of record take precedence over attribute value (will take precedence at line 214)
-                        # (https://github.com/singer-io/tap-outreach/issues/20)
-                        # if fk_field_name in record_flat:
-                        #     raise Exception(
-                        #         '`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
+if stream != "prospects":
+     if fk_field_name in record_flat:
+          raise Exception(
+                                '`{}` exists as both an attribute and generated relationship
+                                name'.format(fk_field_name))
 
                         if data_value == None:
                             record_flat[fk_field_name] = None


### PR DESCRIPTION
# Description of change
* Potential fix for updaterId issue with prospects table (outreach not going to fix on their end)
* Merge community PR -  #21 
 
# Manual QA steps
 - Tested locally the logical check for the relationship and attributes is bypassed for prospects table.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

Co-author - @seanlally 