### PR TITLE
Add unit test cases and make pylint happy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-outreach/bin/activate
-            pylint tap_outreach --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,line-too-long,invalid-name,too-many-lines,consider-using-f-string,too-many-arguments,too-many-locals'
+            pylint tap_outreach --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,line-too-long,invalid-name,too-many-lines,consider-using-f-string,too-many-arguments,too-many-locals,redefined-builtin,too-many-instance-attributes,broad-exception-raised,too-many-nested-blocks,too-many-branches,unspecified-encoding,redefined-outer-name,logging-fstring-interpolation'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,23 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_outreach/schemas/*.json
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-outreach/bin/activate
+            pylint tap_outreach --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,line-too-long,invalid-name,too-many-lines,consider-using-f-string,too-many-arguments,too-many-locals'
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-outreach/bin/activate
+            pip install nose coverage parameterized
+            nosetests --with-coverage --cover-erase --cover-package=tap_outreach --cover-html-dir=htmlcov tests/unittests
+            coverage html
+          when: always
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ setup(name='tap-outreach',
       ],
       extras_require={
           'dev': [
-              'pylint==2.6.2',
               'ipdb',
               'nose',
+              'pylint==2.6.2',
               'requests-mock==1.9.3'
           ]
       },

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ setup(name='tap-outreach',
           'requests==2.23.0',
           'singer-python==5.9.0'
       ],
+      extras_require={
+          'dev': [
+              'pylint==2.6.2',
+              'ipdb',
+              'nose',
+              'requests-mock==1.9.3'
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-outreach=tap_outreach:main

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -10,7 +10,7 @@ from singer.catalog import write_catalog
 
 from tap_outreach.client import OutreachClient
 from tap_outreach.discover import discover
-from tap_outreach.sync import sync
+from tap_outreach.sync import sync_stream
 
 LOGGER = singer.get_logger()
 
@@ -43,7 +43,7 @@ def main():
     else:
         with OutreachClient(parsed_args.config) as client:
             check_auth(client)
-            sync(client,
+            sync_stream(client,
                 parsed_args.config,
                 catalog,
                 parsed_args.state,

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -10,7 +10,7 @@ from singer.catalog import write_catalog
 
 from tap_outreach.client import OutreachClient
 from tap_outreach.discover import discover
-from tap_outreach.sync import sync_stream
+from tap_outreach.sync import sync as _sync
 
 LOGGER = singer.get_logger()
 
@@ -43,7 +43,7 @@ def main():
     else:
         with OutreachClient(parsed_args.config) as client:
             check_auth(client)
-            sync_stream(client,
+            _sync(client,
                 parsed_args.config,
                 catalog,
                 parsed_args.state,

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -29,8 +29,8 @@ def check_auth(client):
         client.get(
             path='stages',
             endpoint='stages')
-    except:
-        raise Exception('Error testing Outreach authentication') from None
+    except Exception as ex:
+        raise Exception('Error testing Outreach authentication') from ex
 
 
 @singer.utils.handle_top_exception(LOGGER)

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -30,7 +30,7 @@ def check_auth(client):
             path='stages',
             endpoint='stages')
     except:
-        raise Exception('Error testing Outreach authentication')
+        raise Exception('Error testing Outreach authentication') from None
 
 
 @singer.utils.handle_top_exception(LOGGER)

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -5,7 +5,6 @@ import backoff
 import requests
 import singer
 from singer import metrics, utils
-from requests.exceptions import ConnectionError
 
 LOGGER = singer.get_logger()
 REQUEST_TIMEOUT = 300
@@ -18,7 +17,7 @@ class RateLimitError(Exception):
     pass
 
 
-class OutreachClient(object):
+class OutreachClient():
     BASE_URL = 'https://api.outreach.io/api/v2/'
 
     def __init__(self, config):
@@ -71,7 +70,7 @@ class OutreachClient(object):
             int(response.headers['x-ratelimit-reset']))
         sleep_time = (reset - datetime.now()).total_seconds() + \
             10  # pad for clock drift/sync issues
-        LOGGER.warn(
+        LOGGER.warning(
             'Sleeping for {:.2f} seconds for next rate limit window'.format(sleep_time))
         time.sleep(sleep_time)
 
@@ -113,7 +112,7 @@ class OutreachClient(object):
             raise Server5xxError(response.text)
 
         if response.status_code == 429:
-            LOGGER.warn('Rate limit hit - 429')
+            LOGGER.warning('Rate limit hit - 429')
             self.sleep_for_reset_period(response)
             raise RateLimitError()
 
@@ -124,7 +123,7 @@ class OutreachClient(object):
             quota_used = 1 - int(response.headers['x-ratelimit-remaining']) / \
                 int(response.headers['x-ratelimit-remaining'])
             if quota_used > float(self.__quota_limit):
-                LOGGER.warn(
+                LOGGER.warning(
                     'Quota used: {:.2f} / {}'.format(quota_used, self.__quota_limit))
                 self.sleep_for_reset_period(response)
 

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -65,7 +65,8 @@ class OutreachClient():
             timedelta(seconds=data['expires_in'] -
                       10)  # pad by 10 seconds for clock drift
 
-    def sleep_for_reset_period(self, response):
+    @staticmethod
+    def sleep_for_reset_period(response):
         reset = datetime.fromtimestamp(
             int(response.headers['x-ratelimit-reset']))
         sleep_time = (reset - datetime.now()).total_seconds() + \

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -2,8 +2,8 @@ import os
 import json
 import singer
 from singer import metadata
-from .sync import STREAM_CONFIGS
 from singer.catalog import Catalog, CatalogEntry, Schema
+from .sync import STREAM_CONFIGS
 
 
 def get_abs_path(path):

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -281,7 +281,8 @@ def sync_endpoint(client, config, state, start_date, stream, mdata):
                     filter_field)] = '{}..inf'.format(paginate_datetime)
                 query_params['sort'] = filter_field
 
-        LOGGER.info(f"{stream.tap_stream_id} - Syncing data since {last_datetime} - page: {page}, limit: {count}, offset: {offset}")
+        LOGGER.info(f"{stream.tap_stream_id} - Syncing data since {last_datetime} \
+                    - page: {page}, limit: {count}, offset: {offset}")
 
         querystring = '&'.join(['%s=%s' % (key, value)
                                 for (key, value) in query_params.items()])

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -322,7 +322,7 @@ def update_current_stream(state, stream_name=None):
     singer.write_state(state)
 
 
-def sync_stream(client, config, catalog, state, start_date):
+def sync(client, config, catalog, state, start_date):
     selected_streams = catalog.get_selected_streams(state)
     selected_streams = sorted(selected_streams, key=lambda x: x.tap_stream_id)
 

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -327,7 +327,7 @@ def update_current_stream(state, stream_name=None):
     singer.write_state(state)
 
 
-def sync(client, config, catalog, state, start_date):
+def sync_stream(client, config, catalog, state, start_date):
     selected_streams = catalog.get_selected_streams(state)
     selected_streams = sorted(selected_streams, key=lambda x: x.tap_stream_id)
 

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -232,7 +232,7 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
                             if fk_field_name in record_flat:
                                 raise Exception('`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
 
-                        if data_value == None:
+                        if data_value is None:
                             record_flat[fk_field_name] = None
                         else:
                             record_flat[fk_field_name] = data_value['id']
@@ -249,7 +249,7 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
         return max_modified
 
 
-def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
+def sync_endpoint(client, config, state, start_date, stream, mdata):
     stream_name = stream.tap_stream_id
     last_datetime = get_bookmark(state, stream_name, start_date)
 
@@ -281,12 +281,7 @@ def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
                     filter_field)] = '{}..inf'.format(paginate_datetime)
                 query_params['sort'] = filter_field
 
-        LOGGER.info('{} - Syncing data since {} - page: {}, limit: {}, offset: {}'.format(
-            stream.tap_stream_id,
-            last_datetime,
-            page,
-            count,
-            offset))
+        LOGGER.info(f"{stream.tap_stream_id} - Syncing data since {last_datetime} - page: {page}, limit: {count}, offset: {offset}")
 
         querystring = '&'.join(['%s=%s' % (key, value)
                                 for (key, value) in query_params.items()])
@@ -334,7 +329,7 @@ def sync_stream(client, config, catalog, state, start_date):
     for stream in selected_streams:
         mdata = metadata.to_map(stream.metadata)
         update_current_stream(state, stream.tap_stream_id)
-        sync_endpoint(client, config, catalog, state,
+        sync_endpoint(client, config, state,
                       start_date, stream, mdata)
 
     update_current_stream(state)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,6 +1,7 @@
 import unittest
 from tap_outreach.sync import process_records
 
+
 class MockSchema:
     def to_dict(self):
         pass
@@ -58,7 +59,7 @@ class TestProcessRecord(unittest.TestCase):
         """call `process_records` function and by passing the `mock_id_records` in
         the param.
         We expect the exception to be raised -
-        `Only `data` or `links` expected in relationships`
+        `null or `id` field expected for `data` relationship`
         """
         mock_records = [{"id": 1, "attributes": {}, "relationships": {"prop": {"data": "data_value"}}}]
         mock_stream = MockStream()
@@ -78,7 +79,7 @@ class TestProcessRecord(unittest.TestCase):
         """call `process_records` function and by passing the `mock_id_records` in
         the param.
         We expect the exception to be raised -
-        `Only `data` or `links` expected in relationships`
+        ``propId` exists as both an attribute and generated relationship name`
         """
         mock_records = [{"id": 1, "attributes": {"propId": 456}, "relationships": {"prop": {"data": {"id": 123}}}}]
         mock_stream = MockStream()

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,95 @@
+import unittest
+from tap_outreach.sync import process_records
+
+class MockSchema:
+    def to_dict(self):
+        pass
+
+
+class MockStream:
+    def __init__(self) -> None:
+        self.tap_stream_id = "mock_stream"
+        self.schema = MockSchema()
+
+
+class TestProcessRecord(unittest.TestCase):
+    """A set of unit tests to ensure that the process_record raise the exception
+    on any discrepancy within the response data"""
+
+    def test_conflict_id(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Error flattening Outeach record - conflict with `id` key`
+        """
+        mock_records = [{"id": 1, "attributes": {"id": 2}}]
+        mock_stream = MockStream()
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                "mock_fks",
+            )
+        self.assertEqual(e.exception.args[0], 'Error flattening Outeach record - conflict with `id` key')
+
+    def test_conflict_data_links(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Only `data` or `links` expected in relationships`
+        """
+        mock_records = [{"id": 1, "attributes": {}, "relationships": {"prop": {"value": ""}}}]
+        mock_stream = MockStream()
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                "mock_fks",
+            )
+        self.assertEqual(e.exception.args[0], 'Only `data` or `links` expected in relationships')
+
+    def test_conflict_data_id(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Only `data` or `links` expected in relationships`
+        """
+        mock_records = [{"id": 1, "attributes": {}, "relationships": {"prop": {"data": "data_value"}}}]
+        mock_stream = MockStream()
+        mock_fks = ["propId"]
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                mock_fks
+            )
+        self.assertEqual(e.exception.args[0], 'null or `id` field expected for `data` relationship')
+
+    def test_conflict_prospects_attributes(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Only `data` or `links` expected in relationships`
+        """
+        mock_records = [{"id": 1, "attributes": {"propId": 456}, "relationships": {"prop": {"data": {"id": 123}}}}]
+        mock_stream = MockStream()
+        mock_fks = ["propId"]
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                mock_fks
+            )
+        self.assertEqual(e.exception.args[0], '`propId` exists as both an attribute and generated relationship name')

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch
+import time
+from requests.models import Response
+from tap_outreach import client
+
+class Mockresponse(Response):
+    def __init__(self, status_code):
+        super().__init__()
+        self.status_code = status_code
+        self.headers = {"x-ratelimit-reset": time.time()}
+    
+    def raise_for_status(self):
+        pass
+    
+class TestRetryLogic(unittest.TestCase):
+    """A set of unit tests to ensure that the retry logic work as expected"""
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_retries_on_5XX(self, mock_session_request):
+        """`OutreachClient.get()` calls a `request` method,to make a request to the API. 
+        We set the mock response status code to `500`.
+
+        We expect the tap to retry this request up to 5 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mock_session_request.return_value = Mockresponse(status_code=500)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5
+        }
+
+        # Initialize the object and call `get()`
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.Server5xxError):
+            outreach_object.get("mock_url", "mock_path")
+        # 5 is the max tries specified in the tap
+        self.assertEquals(5, mock_session_request.call_count)
+
+    # @patch("tap_outreach.client.datetime.fromtimestamp", return_value = )
+    @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_retries_on_429(self, mock_session_request, mock_second):
+        """`OutreachClient.get()` calls a `request` method,to make a request to the API. 
+        We set the mock response status code to `429`. Checks the execution on reaching 
+        rate limit.
+
+        We expect the tap to retry this request up to 5 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mock_session_request.return_value = Mockresponse(status_code=429)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5
+        }
+
+        # Initialize the object and call `get()`
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.RateLimitError):
+            outreach_object.get("mock_url", "mock_path")
+        # 5 is the max tries specified in the tap
+        self.assertEquals(5, mock_session_request.call_count)
+

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+from tap_outreach import sync
+
+
+class MockStream:
+    def __init__(self) -> None:
+        self.tap_stream_id = "accounts"
+
+
+class MockClient:
+    def get(self, path, params, endpoint):
+        return {"data": "mock_data", "links": {}}
+
+
+class SyncEndpoint(unittest.TestCase):
+    """A set of unit tests to ensure the `sync_endpoint` functionality flow"""
+
+    @patch("tap_outreach.sync.write_schema")
+    @patch("tap_outreach.sync.process_records")
+    def test_sync_endpoint(self, mock_process_record, mock_schema):
+        """call `sync_endpoint` function and by passing the mock params.
+        We expect the `process_records` to be called with below params.
+        """
+
+        mock_client = MockClient()
+        mock_stream = MockStream()
+        mock_config = {
+            "start_date": "2023-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5,
+        }
+        mock_state = {
+            "currently_syncing": None,
+            "bookmarks": {
+                "accounts": "2023-07-07T05:30:59.000Z",
+            },
+        }
+
+        sync.sync_endpoint(
+            mock_client,
+            mock_config,
+            "mock_catalog",
+            mock_state,
+            mock_config["start_date"],
+            mock_stream,
+            "mock_mdata",
+        )
+        mock_process_record.assert_called_with(
+            mock_stream,
+            "mock_mdata",
+            "2023-07-07T05:30:59.000Z",
+            "mock_data",
+            "updatedAt",
+            ["creatorId", "ownerId", "updaterId"],
+        )

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -43,7 +43,6 @@ class SyncEndpoint(unittest.TestCase):
         sync.sync_endpoint(
             mock_client,
             mock_config,
-            "mock_catalog",
             mock_state,
             mock_config["start_date"],
             mock_stream,


### PR DESCRIPTION
# Description of change

- Added unit test cases for retry logic, exception handling, and sync_endpoint functionality.
- Update the function name `sync` to `sync_stream` to avoid name conflict.

# Manual QA steps
 - Ensured that the tests covered various scenarios, including edge cases.

 
# Risks
 - No Risks
 
# Rollback steps
 - revert this branch
