### PR TITLE
Add request timeout property

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,23 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_outreach/schemas/*.json
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-outreach/bin/activate
+            pylint tap_outreach --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,line-too-long,invalid-name,too-many-lines,consider-using-f-string,too-many-arguments,too-many-locals,redefined-builtin,too-many-instance-attributes,broad-exception-raised,too-many-nested-blocks,too-many-branches,unspecified-encoding,redefined-outer-name,logging-fstring-interpolation'
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-outreach/bin/activate
+            pip install nose coverage parameterized
+            nosetests --with-coverage --cover-erase --cover-package=tap_outreach --cover-html-dir=htmlcov tests/unittests
+            coverage html
+          when: always
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.9.0
+  * add property - `request_timeout` to set the time limit for the API requests [#30](https://github.com/singer-io/tap-outreach/pull/30)
+
 ## 0.8.0
   * Relationship precedence over attributes for `Prospects` stream [#25](https://github.com/singer-io/tap-outreach/pull/25)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ This tap:
         "redirect_uri": <REDIRECT_URI>,
         "refresh_token": <REFRESH_TOKEN>,
         "quota_limit": <QUOTA_LIMIT>,
-        "page_size": <PAGE_SIZE>
+        "page_size": <PAGE_SIZE>,
+        "request_timeout": 300
     }
     ```
     The following are required values: `start_date`, `client_id`, `client_secret`, `redirect_uri`, `refresh_token`

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,6 @@
     "client_secret": "<CLIENT_SECRET>",
     "redirect_uri": "<REDIRECT_URI>",
     "refresh_token": "<REFRESH_TOKEN>",
-    "quota_limit": "<QUOTA_LIMIT>"
+    "quota_limit": "<QUOTA_LIMIT>",
+    "request_timeout": "<TIMEOUT_LIMIT>"
 }

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ setup(name='tap-outreach',
           'requests==2.23.0',
           'singer-python==5.9.0'
       ],
+      extras_require={
+          'dev': [
+              'ipdb',
+              'nose',
+              'pylint==2.6.2',
+              'requests-mock==1.9.3'
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-outreach=tap_outreach:main

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='0.8.0',
+      version='0.9.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -10,7 +10,7 @@ from singer.catalog import write_catalog
 
 from tap_outreach.client import OutreachClient
 from tap_outreach.discover import discover
-from tap_outreach.sync import sync
+from tap_outreach.sync import sync as _sync
 
 LOGGER = singer.get_logger()
 
@@ -29,8 +29,8 @@ def check_auth(client):
         client.get(
             path='stages',
             endpoint='stages')
-    except:
-        raise Exception('Error testing Outreach authentication')
+    except Exception as ex:
+        raise Exception('Error testing Outreach authentication') from ex
 
 
 @singer.utils.handle_top_exception(LOGGER)
@@ -43,7 +43,7 @@ def main():
     else:
         with OutreachClient(parsed_args.config) as client:
             check_auth(client)
-            sync(client,
+            _sync(client,
                 parsed_args.config,
                 catalog,
                 parsed_args.state,

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -31,18 +31,27 @@ class OutreachClient(object):
         self.__access_token = None
         self.__expires_at = None
         self.__session = requests.Session()
-        # if request_timeout is other than 0,"0" or "" then use request_timeout
-        request_timeout = config.get('request_timeout')
-        if request_timeout and float(request_timeout):
-            self.request_timeout = float(request_timeout)
-        else: # If value is 0,"0" or "" then set default to 300 seconds.
-            self.request_timeout = REQUEST_TIMEOUT
+        self.request_timeout = self.get_request_timeout(config)
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, value, traceback):
         self.__session.close()
+
+    def get_request_timeout(self, config):
+        """
+        Get the request timeout from the config, if not present use the default 300 seconds.
+        """
+        # Get the value of request timeout from config
+        config_request_timeout = config.get('request_timeout')
+
+        # Only return the timeout value if it is passed in the config and the value is not 0, "0" or ""
+        if config_request_timeout and float(config_request_timeout):
+            return float(config_request_timeout)
+
+        # Return default timeout
+        return REQUEST_TIMEOUT
 
     def refresh(self):
         data = self.request(

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -31,27 +31,21 @@ class OutreachClient(object):
         self.__access_token = None
         self.__expires_at = None
         self.__session = requests.Session()
-        self.request_timeout = self.get_request_timeout(config)
+
+        # Get the value of request timeout from config
+        config_request_timeout = config.get('request_timeout')
+        # Only set the timeout value if it is passed in the config and the value is not 0, "0" or ""
+        if config_request_timeout and float(config_request_timeout):
+            self.request_timeout = float(config_request_timeout)
+        else:
+            # Set default timeout
+            self.request_timeout = REQUEST_TIMEOUT
 
     def __enter__(self):
         return self
 
     def __exit__(self, type, value, traceback):
         self.__session.close()
-
-    def get_request_timeout(self, config):
-        """
-        Get the request timeout from the config, if not present use the default 300 seconds.
-        """
-        # Get the value of request timeout from config
-        config_request_timeout = config.get('request_timeout')
-
-        # Only return the timeout value if it is passed in the config and the value is not 0, "0" or ""
-        if config_request_timeout and float(config_request_timeout):
-            return float(config_request_timeout)
-
-        # Return default timeout
-        return REQUEST_TIMEOUT
 
     def refresh(self):
         data = self.request(

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -2,8 +2,8 @@ import os
 import json
 import singer
 from singer import metadata
-from .sync import STREAM_CONFIGS
 from singer.catalog import Catalog, CatalogEntry, Schema
+from .sync import STREAM_CONFIGS
 
 
 def get_abs_path(path):

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -232,7 +232,7 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
                             if fk_field_name in record_flat:
                                 raise Exception('`{}` exists as both an attribute and generated relationship name'.format(fk_field_name))
 
-                        if data_value == None:
+                        if data_value is None:
                             record_flat[fk_field_name] = None
                         else:
                             record_flat[fk_field_name] = data_value['id']
@@ -249,7 +249,7 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
         return max_modified
 
 
-def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
+def sync_endpoint(client, config, state, start_date, stream, mdata):
     stream_name = stream.tap_stream_id
     last_datetime = get_bookmark(state, stream_name, start_date)
 
@@ -281,12 +281,8 @@ def sync_endpoint(client, config, catalog, state, start_date, stream, mdata):
                     filter_field)] = '{}..inf'.format(paginate_datetime)
                 query_params['sort'] = filter_field
 
-        LOGGER.info('{} - Syncing data since {} - page: {}, limit: {}, offset: {}'.format(
-            stream.tap_stream_id,
-            last_datetime,
-            page,
-            count,
-            offset))
+        LOGGER.info(f"{stream.tap_stream_id} - Syncing data since {last_datetime} \
+                    - page: {page}, limit: {count}, offset: {offset}")
 
         querystring = '&'.join(['%s=%s' % (key, value)
                                 for (key, value) in query_params.items()])
@@ -334,7 +330,7 @@ def sync(client, config, catalog, state, start_date):
     for stream in selected_streams:
         mdata = metadata.to_map(stream.metadata)
         update_current_stream(state, stream.tap_stream_id)
-        sync_endpoint(client, config, catalog, state,
+        sync_endpoint(client, config, state,
                       start_date, stream, mdata)
 
     update_current_stream(state)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,0 +1,96 @@
+import unittest
+from tap_outreach.sync import process_records
+
+
+class MockSchema:
+    def to_dict(self):
+        pass
+
+
+class MockStream:
+    def __init__(self) -> None:
+        self.tap_stream_id = "mock_stream"
+        self.schema = MockSchema()
+
+
+class TestProcessRecord(unittest.TestCase):
+    """A set of unit tests to ensure that the process_record raise the exception
+    on any discrepancy within the response data"""
+
+    def test_conflict_id(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Error flattening Outeach record - conflict with `id` key`
+        """
+        mock_records = [{"id": 1, "attributes": {"id": 2}}]
+        mock_stream = MockStream()
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                "mock_fks",
+            )
+        self.assertEqual(e.exception.args[0], 'Error flattening Outeach record - conflict with `id` key')
+
+    def test_conflict_data_links(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Only `data` or `links` expected in relationships`
+        """
+        mock_records = [{"id": 1, "attributes": {}, "relationships": {"prop": {"value": ""}}}]
+        mock_stream = MockStream()
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                "mock_fks",
+            )
+        self.assertEqual(e.exception.args[0], 'Only `data` or `links` expected in relationships')
+
+    def test_conflict_data_id(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `null or `id` field expected for `data` relationship`
+        """
+        mock_records = [{"id": 1, "attributes": {}, "relationships": {"prop": {"data": "data_value"}}}]
+        mock_stream = MockStream()
+        mock_fks = ["propId"]
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                mock_fks
+            )
+        self.assertEqual(e.exception.args[0], 'null or `id` field expected for `data` relationship')
+
+    def test_conflict_prospects_attributes(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        ``propId` exists as both an attribute and generated relationship name`
+        """
+        mock_records = [{"id": 1, "attributes": {"propId": 456}, "relationships": {"prop": {"data": {"id": 123}}}}]
+        mock_stream = MockStream()
+        mock_fks = ["propId"]
+        with self.assertRaises(Exception) as e:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                mock_fks
+            )
+        self.assertEqual(e.exception.args[0], '`propId` exists as both an attribute and generated relationship name')

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest import mock
+from tap_outreach.client import OutreachClient, REQUEST_TIMEOUT
+import requests
+from parameterized import parameterized
+
+class Mockresponse:
+    """ Mock response object class."""
+
+    def __init__(self, status_code, json, raise_error, headers={'X-RateLimit-Remaining': 1}, text=None, content=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+        self.content = content if content is not None else 'github'
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        """ Response JSON method."""
+        return self.text
+
+def get_response(status_code, json={}, raise_error=False, content=None):
+    """ Returns required mock response. """
+    return Mockresponse(status_code, json, raise_error, content=content)
+
+@mock.patch("tap_outreach.client.requests.Session.request")
+class TestTimeoutValue(unittest.TestCase):
+    """
+        Test case to verify the timeout value is set as expected
+    """
+    json = {"key": "value"}
+
+    @parameterized.expand([
+        ["test_int_value", {"request_timeout": 100}, 100.0],
+        ["test_str_value", {"request_timeout": "100"}, 100.0],
+        ["test_empty_value", {"request_timeout": ""}, 300.0],
+        ["test_int_zero_value", {"request_timeout": 0}, 300.0],
+        ["test_str_zero_value", {"request_timeout": "0"}, 300.0],
+        ["test_no_value", {"request_timeout": "0"}, REQUEST_TIMEOUT]
+
+    ])
+    def test_timeout_value_in_config(self, mock_request, name, mock_config, expected_value):
+        """
+        Test if timeout value given in config
+        """
+        # mock response
+        mock_request.return_value = get_response(200, self.json)
+
+        test_client = OutreachClient(mock_config)
+
+        # get the timeout value for assertion
+        timeout = test_client.get_request_timeout(mock_config)
+        test_client.request(method='get', url='')
+
+        # verify that we got expected timeout value
+        self.assertEqual(expected_value, timeout)
+        # verify that the request was called with expected timeout value
+        mock_request.assert_called_with('get', '', timeout=expected_value, headers={'Authorization': 'Bearer None'})
+
+

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -41,6 +41,9 @@ class TestTimeoutValue(unittest.TestCase):
         ["test_empty_value", {"request_timeout": ""}, 300.0],
         ["test_int_zero_value", {"request_timeout": 0}, 300.0],
         ["test_str_zero_value", {"request_timeout": "0"}, 300.0],
+        ["test_str_float_value", {"request_timeout": "100.1"}, 100.1],
+        ["test_float_value", {"request_timeout": 100.1}, 100.1],
+        ["test_none_value", {"request_timeout": None}, 300.0],
         ["test_no_value", {"request_timeout": "0"}, REQUEST_TIMEOUT]
 
     ])
@@ -53,12 +56,8 @@ class TestTimeoutValue(unittest.TestCase):
 
         test_client = OutreachClient(mock_config)
 
-        # get the timeout value for assertion
-        timeout = test_client.get_request_timeout(mock_config)
         test_client.request(method='get', url='')
 
-        # verify that we got expected timeout value
-        self.assertEqual(expected_value, timeout)
         # verify that the request was called with expected timeout value
         mock_request.assert_called_with('get', '', timeout=expected_value, headers={'Authorization': 'Bearer None'})
 

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import patch
+import time
+from requests.models import Response
+from tap_outreach import client
+
+class Mockresponse(Response):
+    def __init__(self, status_code):
+        super().__init__()
+        self.status_code = status_code
+        self.headers = {"x-ratelimit-reset": time.time()}
+    
+    def raise_for_status(self):
+        pass
+    
+class TestRetryLogic(unittest.TestCase):
+    """A set of unit tests to ensure that the retry logic work as expected"""
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_retries_on_5XX(self, mock_session_request):
+        """`OutreachClient.get()` calls a `request` method,to make a request to the API. 
+        We set the mock response status code to `500`.
+
+        We expect the tap to retry this request up to 5 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mock_session_request.return_value = Mockresponse(status_code=500)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5
+        }
+
+        # Initialize the object and call `get()`
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.Server5xxError):
+            outreach_object.get("mock_url", "mock_path")
+        # 5 is the max tries specified in the tap
+        self.assertEquals(5, mock_session_request.call_count)
+
+    @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_retries_on_429(self, mock_session_request, mock_period):
+        """`OutreachClient.get()` calls a `request` method,to make a request to the API. 
+        We set the mock response status code to `429`. Checks the execution on reaching 
+        rate limit.
+
+        We expect the tap to retry this request up to 5 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mock_session_request.return_value = Mockresponse(status_code=429)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5
+        }
+
+        # Initialize the object and call `get()`
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.RateLimitError):
+            outreach_object.get("mock_url", "mock_path")
+        # 5 is the max tries specified in the tap
+        self.assertEquals(5, mock_session_request.call_count)
+
+    @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_retries_on_404(self, mock_session_request, mock_period):
+        """`OutreachClient.get()` calls a `request` method,to make a request to the API. 
+        We set the mock response status code to `404`. Checks the execution on reaching 
+        rate limit.
+
+        We expect the tap to retry this request up to 1 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mock_session_request.return_value = Mockresponse(status_code=404)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5
+        }
+
+        # Initialize the object and call `get()`
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(Exception):
+            outreach_object.get("mock_url", "mock_path")
+        # 5 is the max tries specified in the tap
+        self.assertEquals(1, mock_session_request.call_count)

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import patch
+from tap_outreach import sync
+
+
+class MockStream:
+    def __init__(self) -> None:
+        self.tap_stream_id = "accounts"
+
+
+class MockClient:
+    def get(self, path, params, endpoint):
+        return {"data": "mock_data", "links": {}}
+
+
+class SyncEndpoint(unittest.TestCase):
+    """A set of unit tests to ensure the `sync_endpoint` functionality flow"""
+
+    @patch("tap_outreach.sync.write_schema")
+    @patch("tap_outreach.sync.process_records")
+    def test_sync_endpoint(self, mock_process_record, mock_schema):
+        """call `sync_endpoint` function and by passing the mock params.
+        We expect the `process_records` to be called with below params.
+        """
+
+        mock_client = MockClient()
+        mock_stream = MockStream()
+        mock_config = {
+            "start_date": "2023-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5,
+        }
+        mock_state = {
+            "currently_syncing": None,
+            "bookmarks": {
+                "accounts": "2023-07-07T05:30:59.000Z",
+            },
+        }
+
+        sync.sync_endpoint(
+            mock_client,
+            mock_config,
+            mock_state,
+            mock_config["start_date"],
+            mock_stream,
+            "mock_mdata",
+        )
+        mock_process_record.assert_called_with(
+            mock_stream,
+            "mock_mdata",
+            "2023-07-07T05:30:59.000Z",
+            "mock_data",
+            "updatedAt",
+            ["creatorId", "ownerId", "updaterId"],
+        )


### PR DESCRIPTION
# Description of change
Add request timeout property for tap-outreach

# Manual QA steps
 - Tested tap-execution - discovery and sync.
 - Unit test case for all the different scenarios.
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
