### PR TITLE
TDL-24557: Fix Remaining Quota Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.2
+  * Add handling for new x-rate-limit-remaining structure [#33](https://github.com/singer-io/tap-outreach/pull/33)
+
 ## 1.1.1
   * Dependabot update [#26](https://github.com/singer-io/tap-outreach/pull/26)
 ## 1.1.0
@@ -27,10 +30,10 @@
   * Change from `offset` to `cursor` [pagination](https://api.outreach.io/api/v2/docs#pagination) in `sync.py`. Add [rate limit](https://api.outreach.io/api/v2/docs#rate-limiting) decorator to `client.py`.
 
 ## 0.3.0
-  * changed readme 
+  * changed readme
 
 ## 0.2.0
-  * Additional Endpoints 
+  * Additional Endpoints
 
 ## 0.1.0
   * First iteration

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='1.1.1',
+      version='1.1.2',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -120,9 +120,12 @@ class OutreachClient():
         response.raise_for_status()
 
         if not skip_quota and self.__quota_limit:
-            # quota_limit > (1 - (X-RateLimit-Remaining / X-RateLimit-Limit))
-            quota_used = 1 - int(response.headers['x-ratelimit-remaining']) / \
-                int(response.headers['x-ratelimit-remaining'])
+            # x-rate-limit-remaining now appears to return two distinct ratelimit values, which are not yet documented
+            # eg '9999, 19988'
+            # based on default hourly-user limits, we believe the first value is the hourly limit remaining
+            ratelimitrem = response.headers['x-ratelimit-remaining'].split(", ")[0]
+            quota_used = 1 - int(ratelimitrem) / \
+                int(ratelimitrem)
             if quota_used > float(self.__quota_limit):
                 LOGGER.warning(
                     'Quota used: {:.2f} / {}'.format(quota_used, self.__quota_limit))


### PR DESCRIPTION
# Description of change
Adds handling for new structure of x-rate-limit-remaining response.header by taking the first value in the string

# Manual QA steps
 - Tested with local connection
 
# Risks
 - Minimal; works with a single response string as well.
 
# Rollback steps
 - revert this branch
