### PR TITLE
TDL-24567: Fix refreshing-the-token logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.3
+  * Fix refresh logic for long running pagination requests [#35](https://github.com/singer-io/tap-outreach/pull/35)
+
 ## 1.1.2
   * Add handling for new x-rate-limit-remaining structure [#33](https://github.com/singer-io/tap-outreach/pull/33)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='1.1.2',
+      version='1.1.3',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -47,10 +47,9 @@ class OutreachClient():
         self.__session.close()
 
     def refresh(self):
-        data = self.request(
+        resp = self.__session.request(
             'POST',
             url='https://api.outreach.io/oauth/token',
-            skip_quota=True,
             data={
                 'client_id': self.__client_id,
                 'client_secret': self.__client_secret,
@@ -58,6 +57,7 @@ class OutreachClient():
                 'refresh_token': self.__refresh_token,
                 'grant_type': 'refresh_token'
             })
+        data = resp.json()
 
         self.__access_token = data['access_token']
 
@@ -83,8 +83,7 @@ class OutreachClient():
     # Rate Limit: https://api.outreach.io/api/v2/docs#rate-limiting
     @utils.ratelimit(10000, 3600)
     def request(self, method, path=None, url=None, skip_quota=False, **kwargs):
-        if url is None and \
-            (self.__access_token is None or
+        if  (self.__access_token is None or
              self.__expires_at <= datetime.utcnow()):
             self.refresh()
         else:

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -64,6 +64,7 @@ class OutreachClient():
         self.__expires_at = datetime.utcnow() + \
             timedelta(seconds=data['expires_in'] -
                       10)  # pad by 10 seconds for clock drift
+        LOGGER.info(f"Refreshed access token, expires at {self.__expires_at}")
 
     @staticmethod
     def sleep_for_reset_period(response):
@@ -86,6 +87,8 @@ class OutreachClient():
             (self.__access_token is None or
              self.__expires_at <= datetime.utcnow()):
             self.refresh()
+        else:
+            LOGGER.info("access_token is still valid; not refreshing")
 
         if url is None and path:
             url = '{}{}'.format(self.BASE_URL, path)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -45,7 +45,9 @@ class TestTimeoutValue(unittest.TestCase):
     Test case to verify the timeout value is set as expected
     """
 
-    json = {"key": "value"}
+    json = {"key": "value",
+            "access_token": "None",
+            "expires_in": 10,}
 
     @parameterized.expand(
         [

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -20,7 +20,7 @@ class TestRetryLogic(unittest.TestCase):
 
     @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.requests.Session.request")
-    def test_retries_on_5XX(self, mock_session_request, mock_refresh):
+    def test_retries_on_5XX(self, mock_session_request, _):
         """`OutreachClient.get()` calls a `request` method,to make a request to the API.
         We set the mock response status code to `500`.
 
@@ -46,9 +46,10 @@ class TestRetryLogic(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEquals(5, mock_session_request.call_count)
 
+    @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
     @patch("tap_outreach.client.requests.Session.request")
-    def test_retries_on_429(self, mock_session_request, mock_period):
+    def test_retries_on_429(self, mock_session_request, *args):
         """`OutreachClient.get()` calls a `request` method,to make a request to the API.
         We set the mock response status code to `429`. Checks the execution on reaching
         rate limit.
@@ -75,9 +76,10 @@ class TestRetryLogic(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEquals(5, mock_session_request.call_count)
 
+    @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
     @patch("tap_outreach.client.requests.Session.request")
-    def test_retries_on_404(self, mock_session_request, mock_period):
+    def test_retries_on_404(self, mock_session_request, *args):
         """`OutreachClient.get()` calls a `request` method,to make a request to the API.
         We set the mock response status code to `404`. Checks the execution on reaching
         rate limit.

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -18,8 +18,9 @@ class Mockresponse(Response):
 class TestRetryLogic(unittest.TestCase):
     """A set of unit tests to ensure that the retry logic work as expected"""
 
+    @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.requests.Session.request")
-    def test_retries_on_5XX(self, mock_session_request):
+    def test_retries_on_5XX(self, mock_session_request, mock_refresh):
         """`OutreachClient.get()` calls a `request` method,to make a request to the API.
         We set the mock response status code to `500`.
 


### PR DESCRIPTION
# Description of change
This PR allows long pagination requests to get a fresh token to use.
- Access tokens only live for 2 hours
- If you're on page 5432 of some request, you're probably going to hit that 2 hour limit
- Because we paginate a request and call `request(..., url=next_url, ...)`, the `url is None` check prevents the refresh logic from ever being called

# Manual QA steps
 - Ran the tap and forced the expire_time to be fake expired
 - Saw the refresh logic run
 
# Risks
 - The tap is broken as is if you have enough data
 
# Rollback steps
 - revert this branch, bump the version
