### PR TITLE
Fix for error: Only `data` or `links` expected in relationships

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,14 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-outreach/bin/activate
-            pylint tap_outreach --disable 'missing-module-docstring,missing-function-docstring,missing-class-docstring,line-too-long,invalid-name,too-many-lines,consider-using-f-string,too-many-arguments,too-many-locals,redefined-builtin,too-many-instance-attributes,broad-exception-raised,too-many-nested-blocks,too-many-branches,unspecified-encoding,redefined-outer-name,logging-fstring-interpolation'
+            pip install pylint
+            pylint tap_outreach -d C,R,W
       - run:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-outreach/bin/activate
-            pip install nose coverage parameterized
-            nosetests --with-coverage --cover-erase --cover-package=tap_outreach --cover-html-dir=htmlcov tests/unittests
-            coverage html
+            pip install nose2 parameterized nose2[coverage_plugin]>=0.6.5
+            nose2 --with-coverage -v -s tests/unittests/
           when: always
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-outreach/bin/activate
-            pip install pylint
             pylint tap_outreach -d C,R,W
       - run:
           name: 'Unit Tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.4
   * Fix for error "CRITICAL Only `data` or `links` expected in relationships" [#39](https://github.com/singer-io/tap-outreach/pull/39)
   * Bump requests from 2.31.0 to 2.32.3
+  * singer-python and backoff updates to 6.1.1 and 2.1.1, respectively
 
 ## 1.1.3
   * Fix refresh logic for long running pagination requests [#35](https://github.com/singer-io/tap-outreach/pull/35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1.4
-  * Fix for error "CRITICAL Only `data` or `links` expected in relationships" [#37](https://github.com/singer-io/tap-outreach/pull/37)
+  * Fix for error "CRITICAL Only `data` or `links` expected in relationships" [#39](https://github.com/singer-io/tap-outreach/pull/39)
   * Bump requests from 2.31.0 to 2.32.3
 
 ## 1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.4
+## 1.2.0
   * Fix for error "CRITICAL Only `data` or `links` expected in relationships" [#39](https://github.com/singer-io/tap-outreach/pull/39)
   * Bump requests from 2.31.0 to 2.32.3
   * singer-python and backoff updates to 6.1.1 and 2.1.1, respectively

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.4
+  * Fix for error "CRITICAL Only `data` or `links` expected in relationships" [#37](https://github.com/singer-io/tap-outreach/pull/37)
+  * Bump requests from 2.31.0 to 2.32.3
+
 ## 1.1.3
   * Fix refresh logic for long running pagination requests [#35](https://github.com/singer-io/tap-outreach/pull/35)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='1.1.3',
+      version='1.1.4',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',
@@ -11,7 +11,7 @@ setup(name='tap-outreach',
       py_modules=['tap_outreach'],
       install_requires=[
           'backoff==1.8.0',
-          'requests==2.31.0',
+          'requests==2.32.3',
           'singer-python==5.9.0'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='1.1.4',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(name='tap-outreach',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_outreach'],
       install_requires=[
-          'backoff==1.8.0',
+          'backoff==2.2.1',
           'requests==2.32.3',
-          'singer-python==5.9.0'
+          'singer-python==6.1.1'
       ],
       extras_require={
           'dev': [

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -238,13 +238,9 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
 
             if 'relationships' in record:
                 for prop, value in record['relationships'].items():
-                    if value is None or (not value.get('data') and not value.get('links')):
-                        LOGGER.warning("Skipping invalid relationship: %s", prop)
-                        continue
                     if 'data' not in value and 'links' not in value:
-                        raise Exception(
-                            'Only `data` or `links` expected in relationships')
-
+                            LOGGER.warning("Skipping invalid value: %s only when `data` and `links` not in relationships", prop)
+                            continue
                     fk_field_name = '{}Id'.format(prop)
 
                     if 'data' in value and fk_field_name in fks:

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -239,8 +239,8 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
             if 'relationships' in record:
                 for prop, value in record['relationships'].items():
                     if 'data' not in value and 'links' not in value:
-                            LOGGER.warning("Skipping invalid value: %s only when `data` and `links` not in relationships", prop)
-                            continue
+                        LOGGER.warning("Skipping invalid value: %s only when `data` and `links` not in relationships", prop)
+                        continue
                     fk_field_name = '{}Id'.format(prop)
 
                     if 'data' in value and fk_field_name in fks:

--- a/tap_outreach/sync.py
+++ b/tap_outreach/sync.py
@@ -238,6 +238,9 @@ def process_records(stream, mdata, max_modified, records, filter_field, fks):
 
             if 'relationships' in record:
                 for prop, value in record['relationships'].items():
+                    if value is None or (not value.get('data') and not value.get('links')):
+                        LOGGER.warning("Skipping invalid relationship: %s", prop)
+                        continue
                     if 'data' not in value and 'links' not in value:
                         raise Exception(
                             'Only `data` or `links` expected in relationships')

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -10,9 +10,7 @@ class OutreachAllFieldsTest(AllFieldsTest, OutreachBase):
         "mailboxes": {"creatorId"},
         "prospects": {"personaId"},
         "users": {"roleId"},
-        "call_purposes": {"creatorId"},
         "sequence_states": {"sequenceStepId", "opportunityId"},
-        "call_dispositions": {"creatorId"},
         "tasks": {
             "sequenceTemplateId",
             "accountId",

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -39,28 +39,6 @@ class TestProcessRecord(unittest.TestCase):
             "Error flattening Outeach record - conflict with `id` key",
         )
 
-    def test_conflict_data_links(self):
-        """call `process_records` function and by passing the `mock_id_records` in
-        the param.
-        We expect the exception to be raised -
-        `Only `data` or `links` expected in relationships`
-        """
-        mock_records = [
-            {"id": 1, "attributes": {}, "relationships": {"prop": {"value": ""}}}
-        ]
-        mock_stream = MockStream()
-        with self.assertRaises(Exception) as e:
-            process_records(
-                mock_stream,
-                "mock_mdata",
-                "mock_max_modified",
-                mock_records,
-                "mock_filter_field",
-                "mock_fks",
-            )
-        self.assertEqual(
-            e.exception.args[0], "Only `data` or `links` expected in relationships"
-        )
 
     def test_conflict_data_id(self):
         """call `process_records` function and by passing the `mock_id_records` in

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -39,6 +39,30 @@ class TestProcessRecord(unittest.TestCase):
             "Error flattening Outeach record - conflict with `id` key",
         )
 
+    def test_conflict_data_links(self):
+        """call `process_records` function and by passing the `mock_id_records` in
+        the param.
+        We expect the exception to be raised -
+        `Only `data` or `links` expected in relationships`
+        """
+        mock_records = [
+            {"id": 1, "attributes": {}, "relationships": {"prop": {"value": ""}}}
+        ]
+        mock_stream = MockStream()
+        with self.assertLogs(level="WARNING") as log_statement:
+            process_records(
+                mock_stream,
+                "mock_mdata",
+                "mock_max_modified",
+                mock_records,
+                "mock_filter_field",
+                "mock_fks",
+            )
+
+        self.assertTrue(
+            any("Skipping invalid value" in message for message in log.output),
+            "Expected warning about invalid relationship not found in logs."
+        )
 
     def test_conflict_data_id(self):
         """call `process_records` function and by passing the `mock_id_records` in

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 from tap_outreach.sync import process_records
 
 
@@ -39,29 +40,34 @@ class TestProcessRecord(unittest.TestCase):
             "Error flattening Outeach record - conflict with `id` key",
         )
 
-    def test_conflict_data_links(self):
+    @patch("tap_outreach.sync.LOGGER.warning")
+    @patch("tap_outreach.sync.Transformer.transform")
+    def test_conflict_data_links(self, mock_transform, mock_warning):
         """call `process_records` function and by passing the `mock_id_records` in
         the param.
         We expect the exception to be raised -
         `Only `data` or `links` expected in relationships`
         """
+        # Return a proper dictionary that process_records can work with
+        mock_transform.return_value = {"id": 1, "attributes": {}, "relationships": {}}
+
         mock_records = [
             {"id": 1, "attributes": {}, "relationships": {"prop": {"value": ""}}}
         ]
         mock_stream = MockStream()
-        with self.assertLogs(level="WARNING") as log_statement:
-            process_records(
-                mock_stream,
-                "mock_mdata",
-                "mock_max_modified",
-                mock_records,
-                "mock_filter_field",
-                "mock_fks",
-            )
 
-        self.assertTrue(
-            any("Skipping invalid value" in message for message in log.output),
-            "Expected warning about invalid relationship not found in logs."
+        process_records(
+            mock_stream,
+            "mock_mdata",
+            "mock_max_modified",
+            mock_records,
+            "mock_filter_field",
+            "mock_fks",
+        )
+
+        mock_warning.assert_called_once_with(
+            "Skipping invalid value: %s only when `data` and `links` not in relationships",
+            "prop",
         )
 
     def test_conflict_data_id(self):

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -44,7 +44,7 @@ class TestRetryLogic(unittest.TestCase):
         with self.assertRaises(client.Server5xxError):
             outreach_object.get("mock_url", "mock_path")
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mock_session_request.call_count)
+        self.assertEqual(5, mock_session_request.call_count)
 
     @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
@@ -74,7 +74,7 @@ class TestRetryLogic(unittest.TestCase):
         with self.assertRaises(client.RateLimitError):
             outreach_object.get("mock_url", "mock_path")
         # 5 is the max tries specified in the tap
-        self.assertEquals(5, mock_session_request.call_count)
+        self.assertEqual(5, mock_session_request.call_count)
 
     @patch("tap_outreach.client.OutreachClient.refresh")
     @patch("tap_outreach.client.OutreachClient.sleep_for_reset_period")
@@ -104,4 +104,4 @@ class TestRetryLogic(unittest.TestCase):
         with self.assertRaises(Exception):
             outreach_object.get("mock_url", "mock_path")
         # 5 is the max tries specified in the tap
-        self.assertEquals(1, mock_session_request.call_count)
+        self.assertEqual(1, mock_session_request.call_count)

--- a/tests/unittests/test_sync_endpoint.py
+++ b/tests/unittests/test_sync_endpoint.py
@@ -16,9 +16,10 @@ class MockClient:
 class SyncEndpoint(unittest.TestCase):
     """A set of unit tests to ensure the `sync_endpoint` functionality flow"""
 
+    @patch("tap_outreach.sync.singer.write_state")
     @patch("tap_outreach.sync.write_schema")
     @patch("tap_outreach.sync.process_records")
-    def test_sync_endpoint(self, mock_process_record, mock_schema):
+    def test_sync_endpoint(self, mock_process_record, mock_schema, mock_write_state):
         """call `sync_endpoint` function and by passing the mock params.
         We expect the `process_records` to be called with below params.
         """


### PR DESCRIPTION
# Description of change
- Fixes error: Only `data` or `links` expected in relationships  (#38)
- Bumps requests from 2.31.0 to 2.32.3 (Fixture for CVE: https://github.com/singer-io/tap-outreach/security/dependabot/2)
- Bumps singer-python and backoff to 6.1.1 and 2.2.1, respectively.

# Manual QA steps
 - Tested the changes by applying pr-alpha on client connection
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
