### PR TITLE
Exclude unauth streams from catalog in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 1.3.0
+  * Exclude 403-inaccessible streams from catalog during discovery [#45](https://github.com/singer-io/tap-outreach/pull/45)
+  * Added `OutreachForbiddenError` exception class raised on HTTP 403 responses
+  * Added unit tests for discovery access-check behaviour
+  * bump requests to version 2.34.2 and singer-python to version 6.8.0
+
 # 1.2.2
   * Bump requests to 2.33.0 for security updates [#37](https://github.com/singer-io/tap-outreach/pull/37)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-outreach',
-      version='1.2.2',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the Outreach.io API',
       author='Stitch',
       url='https://singer.io',
@@ -11,8 +11,8 @@ setup(name='tap-outreach',
       py_modules=['tap_outreach'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.33.0',
-          'singer-python==6.1.1'
+          'requests==2.34.2',
+          'singer-python==6.8.0'
       ],
       extras_require={
           'dev': [

--- a/tap_outreach/__init__.py
+++ b/tap_outreach/__init__.py
@@ -36,13 +36,14 @@ def check_auth(client):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-    catalog = parsed_args.catalog if parsed_args.catalog else discover()
 
-    if parsed_args.discover:
-        write_catalog(catalog)
-    else:
-        with OutreachClient(parsed_args.config) as client:
-            check_auth(client)
+    with OutreachClient(parsed_args.config) as client:
+        check_auth(client)
+        if parsed_args.discover:
+            catalog = discover(client)
+            write_catalog(catalog)
+        else:
+            catalog = parsed_args.catalog if parsed_args.catalog else discover(client)
             _sync(client,
                 parsed_args.config,
                 catalog,

--- a/tap_outreach/client.py
+++ b/tap_outreach/client.py
@@ -13,6 +13,10 @@ class Server5xxError(Exception):
     pass
 
 
+class OutreachForbiddenError(Exception):
+    pass
+
+
 class RateLimitError(Exception):
     pass
 
@@ -113,6 +117,10 @@ class OutreachClient():
 
         if response.status_code >= 500:
             raise Server5xxError(response.text)
+
+        if response.status_code == 403:
+            raise OutreachForbiddenError(
+                'HTTP-error-code: 403, Error: {}'.format(response.text))
 
         if response.status_code == 429:
             LOGGER.warning('Rate limit hit - 429')

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -62,21 +62,13 @@ def _check_stream_access(client, stream_name):
     try:
         client.get(path=url_path, params='page[size]=1&count=false', endpoint=stream_name)
         return True
-    except OutreachForbiddenError:
+    except OutreachForbiddenError as exc:
         LOGGER.warning(
-            "Stream '%s' does not have read permission (403), excluding from catalog.",
+            "Permission Error: Stream '%s' %s. Excluding from catalog.",
             stream_name,
+            exc,
         )
         return False
-
-
-def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
-    """
-    Remove child streams from the catalog whose parent stream was excluded.
-    Mutates schemas and field_metadata in place.
-    Note: tap-outreach has no parent-child stream relationships, so this is a no-op.
-    Included for pattern consistency with other Singer taps.
-    """
 
 
 def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
@@ -95,17 +87,14 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         schemas.pop(stream_name, None)
         field_metadata.pop(stream_name, None)
 
-    _prune_inaccessible_children(schemas, field_metadata)
-
-    if inaccessible_streams:
-        if not schemas:
-            raise OutreachForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
+    if not schemas:
+        raise OutreachForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials \
+                do not have 'read' access to any supported streams."
+        )
+    elif inaccessible_streams:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -4,6 +4,9 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from .sync import STREAM_CONFIGS
+from .client import OutreachForbiddenError
+
+LOGGER = singer.get_logger()
 
 
 def get_abs_path(path):
@@ -50,20 +53,84 @@ def get_schemas():
     return schemas, schemas_metadata
 
 
-def discover():
+def _check_stream_access(client, stream_name):
+    """
+    Make a minimal probe request to verify read access to a stream.
+    Returns True if accessible, False if a 403 Forbidden error is raised.
+    """
+    url_path = STREAM_CONFIGS[stream_name]['url_path']
+    try:
+        client.get(path=url_path, params='page[size]=1&count=false', endpoint=stream_name)
+        return True
+    except OutreachForbiddenError:
+        LOGGER.warning(
+            "Stream '%s' does not have read permission (403), excluding from catalog.",
+            stream_name,
+        )
+        return False
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    Note: tap-outreach has no parent-child stream relationships, so this is a no-op.
+    Included for pattern consistency with other Singer taps.
+    """
+
+
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams from
+    schemas and field_metadata in place.
+    Raises OutreachForbiddenError if no streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name in list(schemas.keys())
+        if not _check_stream_access(client, stream_name)
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if inaccessible_streams:
+        if not schemas:
+            raise OutreachForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover(client) -> Catalog:
+    """
+    Run the discovery mode, prepare the catalog file and return the catalog.
+    Access to each stream is verified using the provided client and streams
+    the credentials cannot read are excluded from the returned catalog.
+    """
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():
         schema = Schema.from_dict(schema_dict)
-        metadata = field_metadata[stream_name]
+        mdata = field_metadata[stream_name]
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
             tap_stream_id=stream_name,
             key_properties=['id'],
             schema=schema,
-            metadata=metadata
+            metadata=mdata
         ))
 
     return catalog

--- a/tap_outreach/discover.py
+++ b/tap_outreach/discover.py
@@ -64,9 +64,9 @@ def _check_stream_access(client, stream_name):
         return True
     except OutreachForbiddenError as exc:
         LOGGER.warning(
-            "Permission Error: Stream '%s' %s. Excluding from catalog.",
+            "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
             stream_name,
-            exc,
+            str(exc),
         )
         return False
 
@@ -89,8 +89,8 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
 
     if not schemas:
         raise OutreachForbiddenError(
-            "HTTP-error-code: 403, Error: The credentials \
-                do not have 'read' access to any supported streams."
+            "HTTP-error-code: 403, Error: The credentials " \
+            "do not have 'read' access to any supported streams."
         )
     elif inaccessible_streams:
         LOGGER.warning(

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -24,10 +24,8 @@ class OutreachBookmarkTest(BookmarkTest, OutreachBase):
             "prospects": {"updatedAt": "2016-07-07T14:22:04.624Z"},
             "stages": {"updatedAt": "2020-05-06T18:54:08.250Z"},
             "sequences": {"updatedAt": "2020-11-06T20:17:17Z"},
-            "sequence_states": {"updatedAt": "2018-01-17T13:45:25.125Z"},
             "sequence_steps": {"updatedAt": "2019-10-10T03:23:15.466Z"},
             "tasks": {"updatedAt": "2020-05-06T18:54:08.250Z"},
-            "teams": {"updatedAt": "2020-11-06T20:17:17Z"},
             "users": {"updatedAt": "2019-10-10T03:23:15.466Z"},
         }
     }
@@ -42,7 +40,7 @@ class OutreachBookmarkTest(BookmarkTest, OutreachBase):
 
     def streams_to_test(self):
         # Skip streams due to lack of test data
-        streams_to_exclude = {"mailings", "duties", "sequence_templates"}
+        streams_to_exclude = {"mailings", "duties", "sequence_templates", "teams", "sequence_states"}
         return self.expected_stream_names().difference(streams_to_exclude)
 
     def calculate_new_bookmarks(self):

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -14,7 +14,7 @@ class OutreachStartdateTest(StartDateTest, OutreachBase):
 
     def streams_to_test(self):
         # Skip streams due to lack of test data
-        streams_to_exclude = {"mailings", "prospects", "sequence_states", "duties", "sequence_templates"}
+        streams_to_exclude = {"mailings", "prospects", "sequence_states", "duties", "sequence_templates", "teams"}
         return self.expected_stream_names().difference(streams_to_exclude)
 
     @property

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,11 +1,10 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from tap_outreach.client import OutreachForbiddenError
 from tap_outreach.discover import (
     _apply_access_checks,
     _check_stream_access,
-    _prune_inaccessible_children,
     discover,
     get_schemas,
 )
@@ -91,27 +90,6 @@ class TestCheckStreamAccess(unittest.TestCase):
             _check_stream_access(self.client, self.stream_name)
 
 
-class TestPruneInaccessibleChildren(unittest.TestCase):
-    """
-    tap-outreach has no parent-child relationships so this is a no-op,
-    but should not mutate the dicts passed in.
-    """
-
-    def test_no_op_for_flat_streams(self):
-        schemas = {'accounts': {}, 'calls': {}}
-        field_metadata = {'accounts': [], 'calls': []}
-        _prune_inaccessible_children(schemas, field_metadata)
-        self.assertEqual(set(schemas.keys()), {'accounts', 'calls'})
-        self.assertEqual(set(field_metadata.keys()), {'accounts', 'calls'})
-
-    def test_empty_dicts_are_safe(self):
-        schemas = {}
-        field_metadata = {}
-        _prune_inaccessible_children(schemas, field_metadata)
-        self.assertEqual(schemas, {})
-        self.assertEqual(field_metadata, {})
-
-
 class TestApplyAccessChecks(unittest.TestCase):
     """Unit tests for _apply_access_checks()."""
 
@@ -146,7 +124,7 @@ class TestApplyAccessChecks(unittest.TestCase):
             _apply_access_checks(self.client, self.schemas, self.field_metadata)
             mock_logger.warning.assert_called_once()
             warning_msg = mock_logger.warning.call_args[0][0]
-            self.assertIn("do not have 'read' access", warning_msg)
+            self.assertIn("No 'read' access", warning_msg)
 
     @patch('tap_outreach.discover._check_stream_access', return_value=True)
     def test_all_accessible_no_warning_logged(self, mock_check):
@@ -159,7 +137,7 @@ class TestApplyAccessChecks(unittest.TestCase):
         with self.assertRaises(OutreachForbiddenError) as ctx:
             _apply_access_checks(self.client, self.schemas, self.field_metadata)
         self.assertIn('403', str(ctx.exception))
-        self.assertIn("do not have 'read' access", str(ctx.exception))
+        self.assertIn("do not have 'read' access to any supported streams", str(ctx.exception))
 
 
 class TestDiscover(unittest.TestCase):
@@ -208,7 +186,3 @@ class TestDiscover(unittest.TestCase):
         with patch('tap_outreach.discover._check_stream_access', return_value=False):
             with self.assertRaises(OutreachForbiddenError):
                 discover(self.client)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -139,6 +139,17 @@ class TestApplyAccessChecks(unittest.TestCase):
         self.assertIn('403', str(ctx.exception))
         self.assertIn("do not have 'read' access to any supported streams", str(ctx.exception))
 
+    @patch('tap_outreach.discover._check_stream_access', return_value=False)
+    def test_all_inaccessible_exact_error_message(self, mock_check):
+        """Validate the exact error message raised when no streams are accessible."""
+        expected_message = (
+            "HTTP-error-code: 403, Error: The credentials "
+            "do not have 'read' access to any supported streams."
+        )
+        with self.assertRaises(OutreachForbiddenError) as ctx:
+            _apply_access_checks(self.client, self.schemas, self.field_metadata)
+        self.assertEqual(expected_message, str(ctx.exception))
+
 
 class TestDiscover(unittest.TestCase):
     """Unit tests for discover()."""

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,214 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from tap_outreach.client import OutreachForbiddenError
+from tap_outreach.discover import (
+    _apply_access_checks,
+    _check_stream_access,
+    _prune_inaccessible_children,
+    discover,
+    get_schemas,
+)
+from tap_outreach.sync import STREAM_CONFIGS
+
+
+class TestGetSchemas(unittest.TestCase):
+    """Verify that get_schemas() loads schemas for all expected streams."""
+
+    def test_all_streams_have_schemas(self):
+        schemas, field_metadata = get_schemas()
+        self.assertEqual(set(schemas.keys()), set(STREAM_CONFIGS.keys()))
+        self.assertEqual(set(field_metadata.keys()), set(STREAM_CONFIGS.keys()))
+
+    def test_schema_is_dict(self):
+        schemas, _ = get_schemas()
+        for stream_name, schema in schemas.items():
+            self.assertIsInstance(schema, dict, f"Schema for '{stream_name}' should be a dict")
+
+    def test_metadata_is_list(self):
+        _, field_metadata = get_schemas()
+        for stream_name, meta in field_metadata.items():
+            self.assertIsInstance(meta, list, f"Metadata for '{stream_name}' should be a list")
+
+    def test_incremental_streams_have_replication_key_in_metadata(self):
+        schemas, field_metadata = get_schemas()
+        for stream_name, config in STREAM_CONFIGS.items():
+            if config['replication'] == 'incremental':
+                meta_entries = field_metadata[stream_name]
+                automatic_fields = [
+                    e['metadata'].get('inclusion')
+                    for e in meta_entries
+                    if e.get('breadcrumb') == ('properties', config['filter_field'])
+                ]
+                self.assertIn(
+                    'automatic', automatic_fields,
+                    f"Stream '{stream_name}' filter_field should have inclusion=automatic"
+                )
+
+    def test_full_table_streams_have_correct_replication_method(self):
+        _, field_metadata = get_schemas()
+        for stream_name, config in STREAM_CONFIGS.items():
+            if config['replication'] == 'full':
+                root_meta = next(
+                    (e['metadata'] for e in field_metadata[stream_name] if e.get('breadcrumb') == ()),
+                    {}
+                )
+                self.assertEqual(
+                    root_meta.get('forced-replication-method'), 'FULL_TABLE',
+                    f"Stream '{stream_name}' should have FULL_TABLE replication"
+                )
+
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Unit tests for _check_stream_access()."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.stream_name = 'accounts'
+
+    def test_returns_true_when_accessible(self):
+        self.client.get.return_value = {'data': []}
+        result = _check_stream_access(self.client, self.stream_name)
+        self.assertTrue(result)
+
+    def test_returns_false_on_forbidden(self):
+        self.client.get.side_effect = OutreachForbiddenError('403 Forbidden')
+        result = _check_stream_access(self.client, self.stream_name)
+        self.assertFalse(result)
+
+    def test_probe_uses_correct_url_path(self):
+        self.client.get.return_value = {'data': []}
+        _check_stream_access(self.client, self.stream_name)
+        self.client.get.assert_called_once_with(
+            path=STREAM_CONFIGS[self.stream_name]['url_path'],
+            params='page[size]=1&count=false',
+            endpoint=self.stream_name,
+        )
+
+    def test_non_403_exception_propagates(self):
+        self.client.get.side_effect = Exception('Network error')
+        with self.assertRaises(Exception):
+            _check_stream_access(self.client, self.stream_name)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """
+    tap-outreach has no parent-child relationships so this is a no-op,
+    but should not mutate the dicts passed in.
+    """
+
+    def test_no_op_for_flat_streams(self):
+        schemas = {'accounts': {}, 'calls': {}}
+        field_metadata = {'accounts': [], 'calls': []}
+        _prune_inaccessible_children(schemas, field_metadata)
+        self.assertEqual(set(schemas.keys()), {'accounts', 'calls'})
+        self.assertEqual(set(field_metadata.keys()), {'accounts', 'calls'})
+
+    def test_empty_dicts_are_safe(self):
+        schemas = {}
+        field_metadata = {}
+        _prune_inaccessible_children(schemas, field_metadata)
+        self.assertEqual(schemas, {})
+        self.assertEqual(field_metadata, {})
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Unit tests for _apply_access_checks()."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.schemas = {'accounts': {'type': 'object'}, 'calls': {'type': 'object'}}
+        self.field_metadata = {'accounts': [], 'calls': []}
+
+    @patch('tap_outreach.discover._check_stream_access', return_value=True)
+    def test_all_accessible_leaves_dicts_unchanged(self, mock_check):
+        _apply_access_checks(self.client, self.schemas, self.field_metadata)
+        self.assertIn('accounts', self.schemas)
+        self.assertIn('calls', self.schemas)
+
+    @patch('tap_outreach.discover._check_stream_access')
+    def test_inaccessible_stream_is_removed(self, mock_check):
+        mock_check.side_effect = lambda client, name: name != 'calls'
+        _apply_access_checks(self.client, self.schemas, self.field_metadata)
+        self.assertIn('accounts', self.schemas)
+        self.assertNotIn('calls', self.schemas)
+        self.assertNotIn('calls', self.field_metadata)
+
+    @patch('tap_outreach.discover._check_stream_access', return_value=False)
+    def test_all_inaccessible_raises_forbidden_error(self, mock_check):
+        with self.assertRaises(OutreachForbiddenError):
+            _apply_access_checks(self.client, self.schemas, self.field_metadata)
+
+    @patch('tap_outreach.discover._check_stream_access')
+    def test_partial_inaccessible_logs_warning(self, mock_check):
+        mock_check.side_effect = lambda client, name: name != 'calls'
+        with patch('tap_outreach.discover.LOGGER') as mock_logger:
+            _apply_access_checks(self.client, self.schemas, self.field_metadata)
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            self.assertIn("do not have 'read' access", warning_msg)
+
+    @patch('tap_outreach.discover._check_stream_access', return_value=True)
+    def test_all_accessible_no_warning_logged(self, mock_check):
+        with patch('tap_outreach.discover.LOGGER') as mock_logger:
+            _apply_access_checks(self.client, self.schemas, self.field_metadata)
+            mock_logger.warning.assert_not_called()
+
+    @patch('tap_outreach.discover._check_stream_access', return_value=False)
+    def test_all_inaccessible_error_message(self, mock_check):
+        with self.assertRaises(OutreachForbiddenError) as ctx:
+            _apply_access_checks(self.client, self.schemas, self.field_metadata)
+        self.assertIn('403', str(ctx.exception))
+        self.assertIn("do not have 'read' access", str(ctx.exception))
+
+
+class TestDiscover(unittest.TestCase):
+    """Unit tests for discover()."""
+
+    def setUp(self):
+        self.client = MagicMock()
+
+    @patch('tap_outreach.discover._apply_access_checks')
+    def test_discover_returns_catalog(self, mock_access):
+        from singer.catalog import Catalog
+        catalog = discover(self.client)
+        self.assertIsInstance(catalog, Catalog)
+
+    @patch('tap_outreach.discover._apply_access_checks')
+    def test_discover_catalog_contains_all_streams(self, mock_access):
+        catalog = discover(self.client)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, set(STREAM_CONFIGS.keys()))
+
+    @patch('tap_outreach.discover._apply_access_checks')
+    def test_discover_streams_have_key_properties(self, mock_access):
+        catalog = discover(self.client)
+        for stream in catalog.streams:
+            self.assertEqual(stream.key_properties, ['id'])
+
+    @patch('tap_outreach.discover._apply_access_checks')
+    def test_discover_passes_client_to_access_checks(self, mock_access):
+        discover(self.client)
+        mock_access.assert_called_once()
+        args = mock_access.call_args[0]
+        self.assertIs(args[0], self.client)
+
+    @patch('tap_outreach.discover._apply_access_checks')
+    def test_discover_excludes_stream_removed_by_access_check(self, mock_access):
+        def remove_calls(client, schemas, field_metadata):
+            schemas.pop('calls', None)
+            field_metadata.pop('calls', None)
+
+        mock_access.side_effect = remove_calls
+        catalog = discover(self.client)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn('calls', stream_ids)
+
+    def test_discover_raises_when_all_streams_forbidden(self):
+        with patch('tap_outreach.discover._check_stream_access', return_value=False):
+            with self.assertRaises(OutreachForbiddenError):
+                discover(self.client)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -105,3 +105,46 @@ class TestRetryLogic(unittest.TestCase):
             outreach_object.get("mock_url", "mock_path")
         # 5 is the max tries specified in the tap
         self.assertEqual(1, mock_session_request.call_count)
+
+    @patch("tap_outreach.client.OutreachClient.refresh")
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_raises_forbidden_error_on_403(self, mock_session_request, _):
+        """`OutreachClient.get()` raises `OutreachForbiddenError` when the API
+        returns a 403 Forbidden response.
+        """
+        mock_session_request.return_value = Mockresponse(status_code=403)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5,
+        }
+
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.OutreachForbiddenError):
+            outreach_object.get("mock_url", "mock_path")
+
+    @patch("tap_outreach.client.OutreachClient.refresh")
+    @patch("tap_outreach.client.requests.Session.request")
+    def test_no_retry_on_403(self, mock_session_request, _):
+        """`OutreachClient.get()` does not retry on a 403 Forbidden response.
+        Unlike 5xx or 429 errors, a 403 is not a transient error — the request
+        should fail immediately after a single attempt.
+        """
+        mock_session_request.return_value = Mockresponse(status_code=403)
+        mocked_config = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "client_id": "mock_client",
+            "client_secret": "mock_secret",
+            "redirect_uri": "mock_uri",
+            "refresh_token": "mock_token",
+            "request_timeout": 5,
+        }
+
+        outreach_object = client.OutreachClient(mocked_config)
+        with self.assertRaises(client.OutreachForbiddenError):
+            outreach_object.get("mock_url", "mock_path")
+        # Must be exactly 1 — 403 should not trigger any retry
+        self.assertEqual(1, mock_session_request.call_count)


### PR DESCRIPTION
# Description of change
This PR modifies the: 
- discovery flow so that streams the API credentials cannot access (HTTP 403 Forbidden) are gracefully excluded from the catalog instead of causing discovery to fail entirely. 
- If credentials have partial access, discovery succeeds with the accessible subset of streams and emits warnings for the excluded ones. If credentials have no access to any stream, a clear `OutreachForbiddenError` is raised.
- bump requests to version 2.34.2 and singer-python to version 6.8.0

# Changes
 - tap_outreach/client.py
Added OutreachForbiddenError exception class
The request() method now raises OutreachForbiddenError on HTTP 403 responses before calling raise_for_status()

- tap_outreach/discover.py
     - discover() signature changed from discover() → discover(client) to enable access probing during discovery
     - Added _check_stream_access(client, stream_name) — makes a minimal probe request (page[size]=1) per stream to verify read access
     - Added _apply_access_checks(client, schemas, field_metadata) — removes inaccessible streams from the catalog in-place; raises OutreachForbiddenError if no streams are accessible
     - Added _prune_inaccessible_children(schemas, field_metadata) — included for pattern consistency with other taps (tap-outreach has no parent-child stream relationships, so this is a no-op)

- tap_outreach/__init__.py
  - OutreachClient context manager now wraps both discovery and sync paths
  - discover(client) receives the authenticated client in both modes

- tests/unittests/test_discovery.py (new file)
     - 23 unit tests covering:
          - Schema loading and metadata validation for all streams
          - _check_stream_access: accessible, forbidden (403), non-403 errors, correct URL probe
          - _apply_access_checks: all accessible, partial access, full denial, warning logging
          - discover(): catalog structure, stream selection, access-check integration, forbidden error propagation
  
- CHANGELOG.md / setup.py — version bumped to 1.3.0

# Manual QA steps
- [x]  Discovery: Not Running
- [x]  Sync: Not Running
- [x]  Unit Tests: Running
- [x]  Integration test: Not Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
